### PR TITLE
Lots of changes

### DIFF
--- a/lib/fcm_client.dart
+++ b/lib/fcm_client.dart
@@ -7,7 +7,6 @@ import 'utils.dart';
 /// https://console.firebase.google.com/project/ie-mahjong-tournament/notification/compose
 /// in foreground mode, background mode and when app is closed!
 Future<void> setupFCM() async {
-
   await setNotifierEvents();
   // notifications work when app is closed, on Moto G54, Moto G 5G, and emulated
   await getFCMToken();
@@ -29,7 +28,6 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 }
 
 // TODO offer the user a notification-reset option, by forcing fcm token refresh
-
 Future<void> subscribeToTopic(String topic, String? previous) async {
   // this subscription persists through app restarts and changes of token
   if (previous != null) {
@@ -51,7 +49,7 @@ Future<void> unsubscribeFromTournament(String topic, int playerCount) async {
 }
 
 Future<void> getFCMToken() async {
-  final String fcmToken = await messaging.getToken() ?? '';
+  //final String fcmToken = await messaging.getToken() ?? '';
 
   messaging.onTokenRefresh.listen((fcmToken) {
     Log.debug('FCM token refreshed: $fcmToken');
@@ -59,7 +57,8 @@ Future<void> getFCMToken() async {
     // Note: This callback is fired at each app startup and whenever a new
     // token is generated.
   }).onError((err) {
-    Log.error('Failed to set listener for fcmToken in onTokenRefresh: ${err.message}');
+    Log.error(
+        'Failed to set listener for fcmToken in onTokenRefresh: ${err.message}');
     // Error getting token.
   });
 }

--- a/lib/info.dart
+++ b/lib/info.dart
@@ -16,12 +16,20 @@ class TournamentInfo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AllState, TournamentInfoState>(
-      converter: (store) => (
-        tournament: store.state.tournament!,
-        schedule: store.state.schedule!,
-      ),
+    return StoreConnector<AllState, TournamentInfoState?>(
+      distinct: true,
+      converter: (store) =>
+          store.state.tournament != null && store.state.schedule != null
+              ? (
+                  tournament: store.state.tournament!,
+                  schedule: store.state.schedule!,
+                )
+              : null,
       builder: (context, state) {
+        if (state == null) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
         return ListView(
           children: [
             ListTile(
@@ -72,7 +80,7 @@ class TournamentInfo extends StatelessWidget {
                       ),
                     ),
                   ]),
-                  for (final schedule in state.schedule.hanchan.values)
+                  for (final schedule in state.schedule.rounds.values)
                     TableRow(children: [
                       Padding(
                         padding: const EdgeInsets.all(8),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,7 +27,7 @@ Future main() async {
   await setupFCM();
   await Alarm.init();
   DB.instance.getTournaments();
-  DB.instance.getTournamentFromId(prefs.getString('tournamentId') ?? '');
+  DB.instance.getTournamentFromId(prefs.getString('tournamentId'));
   SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
     statusBarColor: Colors.black, //top bar color
     statusBarIconBrightness: Brightness.light, //top bar icons
@@ -54,22 +54,20 @@ class _MyAppState extends State<_MyApp> {
 
   // Unhandled Exception: Looking up a deactivated widget's ancestor is unsafe.
   // E/flutter ( 5008): At this point the state of the widget's element tree is no longer stable.
-  Future<void> alarmIsRinging(AlarmSettings settings) async {
-    await globalNavigatorKey.currentState?.push(
-      MaterialPageRoute<void>(
-        builder: (context) => AlarmScreen(settings: settings),
-      ),
-    );
-  }
+  Future<void> alarmIsRinging(AlarmSettings settings) =>
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (context) => AlarmScreen(settings: settings),
+        ),
+      );
 
   @override
   Widget build(BuildContext context) {
     return StoreProvider<AllState>(
       store: store,
       child: MaterialApp(
-        debugShowCheckedModeBanner:false,
+        debugShowCheckedModeBanner: false,
         initialRoute: ROUTES.home,
-        navigatorKey: globalNavigatorKey,
         scaffoldMessengerKey: DB.instance.scaffoldMessengerKey,
         title: 'All-Ireland Mahjong Tournaments',
         theme: ThemeData(

--- a/lib/notifications.dart
+++ b/lib/notifications.dart
@@ -1,5 +1,4 @@
 import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import 'firebase_options.dart';
@@ -9,7 +8,7 @@ Future<void> setNotifierEvents() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
-  NotificationSettings settings = await messaging.requestPermission(
+  await messaging.requestPermission(
     alert: true,
     announcement: false,
     badge: true,

--- a/lib/player_list.dart
+++ b/lib/player_list.dart
@@ -91,24 +91,26 @@ class PlayerList extends StatelessWidget {
             color: Colors.green,
           ),
           title: Text(player.name),
-          onTap: () {
+          onTap: () async {
             if (player.id == selected) {
               store.dispatch(const SetPlayerIdAction(playerId: null));
-              DB.instance.setAllAlarms();
+              await DB.instance.setAllAlarms();
 
-              messaging.unsubscribeFromTopic(
+              await messaging.unsubscribeFromTopic(
                 '${store.state.tournamentId}-$selected',
               );
             } else {
               store.dispatch(SetPlayerIdAction(playerId: player.id));
-              DB.instance.setAllAlarms();
+              await DB.instance.setAllAlarms();
 
-              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                content: Text(
-                  '${player.name} will be highlighted in seating & scores, and you will receive updates for them',
-                ),
-              ));
-              subscribeToTopic(
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                  content: Text(
+                    '${player.name} will be highlighted in seating & scores, and you will receive updates for them',
+                  ),
+                ));
+              }
+              await subscribeToTopic(
                 '${store.state.tournamentId}-${player.id}',
                 '${store.state.tournamentId}-$selected',
               );

--- a/lib/player_list.dart
+++ b/lib/player_list.dart
@@ -24,6 +24,7 @@ class _PlayersState extends State<Players> {
   @override
   Widget build(BuildContext context) {
     return StoreConnector<AllState, PlayersState>(
+      distinct: true,
       converter: (store) => (
         players: store.state.players,
         selected: store.state.selected,
@@ -100,7 +101,7 @@ class PlayerList extends StatelessWidget {
               DB.instance.setAllAlarms();
 
               messaging.unsubscribeFromTopic(
-                '${store.state.tournamentId}-$selected',
+                '${store.state.tournament?.id}-$selected',
               );
             } else {
               store.dispatch(SetPlayerIdAction(playerId: player.id));
@@ -112,8 +113,8 @@ class PlayerList extends StatelessWidget {
                 ),
               ));
               subscribeToTopic(
-                '${store.state.tournamentId}-${player.id}',
-                '${store.state.tournamentId}-$selected',
+                '${store.state.tournament?.id}-${player.id}',
+                '${store.state.tournament?.id}-$selected',
               );
             }
           },

--- a/lib/player_list.dart
+++ b/lib/player_list.dart
@@ -31,22 +31,25 @@ class _PlayersState extends State<Players> {
       builder: (context, state) {
         return Column(
           children: [
-            Padding(
-              padding: const EdgeInsets.all(8),
-              child: TextField(
-                controller: textController,
-                decoration: InputDecoration(
-                  prefixIcon: const Icon(Icons.search),
-                  suffixIcon: textController.text.isNotEmpty
-                      ? IconButton(
-                          onPressed: () =>
-                              setState(() => textController.clear()),
-                          icon: const Icon(Icons.clear),
-                        )
-                      : null,
-                  hintText: 'Player search',
+            Material(
+              color: Theme.of(context).canvasColor,
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: TextField(
+                  controller: textController,
+                  decoration: InputDecoration(
+                    prefixIcon: const Icon(Icons.search),
+                    suffixIcon: textController.text.isNotEmpty
+                        ? IconButton(
+                            onPressed: () =>
+                                setState(() => textController.clear()),
+                            icon: const Icon(Icons.clear),
+                          )
+                        : null,
+                    hintText: 'Player search',
+                  ),
+                  onChanged: (value) => setState(() {}),
                 ),
-                onChanged: (value) => setState(() {}),
               ),
             ),
             Expanded(
@@ -91,26 +94,24 @@ class PlayerList extends StatelessWidget {
             color: Colors.green,
           ),
           title: Text(player.name),
-          onTap: () async {
+          onTap: () {
             if (player.id == selected) {
               store.dispatch(const SetPlayerIdAction(playerId: null));
-              await DB.instance.setAllAlarms();
+              DB.instance.setAllAlarms();
 
-              await messaging.unsubscribeFromTopic(
+              messaging.unsubscribeFromTopic(
                 '${store.state.tournamentId}-$selected',
               );
             } else {
               store.dispatch(SetPlayerIdAction(playerId: player.id));
-              await DB.instance.setAllAlarms();
+              DB.instance.setAllAlarms();
 
-              if (context.mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                  content: Text(
-                    '${player.name} will be highlighted in seating & scores, and you will receive updates for them',
-                  ),
-                ));
-              }
-              await subscribeToTopic(
+              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                content: Text(
+                  '${player.name} will be highlighted in seating & scores, and you will receive updates for them',
+                ),
+              ));
+              subscribeToTopic(
                 '${store.state.tournamentId}-${player.id}',
                 '${store.state.tournamentId}-$selected',
               );

--- a/lib/seats.dart
+++ b/lib/seats.dart
@@ -1,16 +1,66 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
+import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 import 'package:intl/intl.dart';
 
 import 'store.dart';
 import 'utils.dart';
 
+typedef Round = ({
+  String id,
+  String name,
+  DateTime start,
+  List<RoundTable> tables,
+});
+
+typedef RoundTable = ({
+  String name,
+  Map<Winds, Player> players,
+});
+
+extension on RoundTable {
+  bool hasPlayerId(int? playerId) =>
+      players.values.any((e) => e.id == playerId);
+}
+
+List<Round> toRoundList(
+  List<RoundState> rounds,
+  ScheduleState schedule,
+  List<Player> players,
+) {
+  final playerById = Map.fromEntries(
+    players.map((e) => MapEntry(e.id, e.name)),
+  );
+  final roundById = schedule.rounds;
+  return [
+    for (final round in rounds)
+      (
+        id: round.id,
+        name: roundById[round.id]!.name,
+        start: roundById[round.id]!.start,
+        tables: [
+          for (final MapEntry(key: tableName, value: playerIds)
+              in round.tables.entries)
+            (
+              name: tableName,
+              players: {
+                for (final wind in Winds.values)
+                  wind: Player(
+                    playerIds[wind.index],
+                    playerById[playerIds[wind.index]]!,
+                  ),
+              },
+            )
+        ],
+      ),
+  ];
+}
+
 typedef SeatingState = ({
-  List<RoundState> theseSeats,
-  List<RoundState> seating,
+  List<Round> rounds,
   int? selected,
   int roundDone,
-  ScheduleState schedule
+  bool japaneseWinds,
 });
 
 class Seating extends StatefulWidget {
@@ -27,163 +77,194 @@ class _SeatingState extends State<Seating> {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AllState, SeatingState>(
-      converter: (store) => (
-        theseSeats: store.state.theseSeats,
-        seating: store.state.seating,
-        selected: store.state.selected,
-        roundDone: store.state.roundDone,
-        schedule: store.state.schedule!,
-      ),
+    return StoreConnector<AllState, SeatingState?>(
+      distinct: true,
+      converter: (store) => store.state.schedule != null
+          ? (
+              rounds: toRoundList(
+                store.state.seating,
+                store.state.schedule!,
+                store.state.players,
+              ),
+              selected: store.state.selected,
+              roundDone: store.state.roundDone,
+              japaneseWinds: prefs.getBool('japaneseWinds') ?? false,
+            )
+          : null,
       builder: (context, state) {
-        final haveSelection = state.selected != null;
-        final seats =
-            haveSelection && !showAll ? state.theseSeats : state.seating;
-        if (seats.isEmpty) {
-          return const Center(child: Text('No seating schedule available'));
+        if (state == null) {
+          return const Center(child: CircularProgressIndicator());
         }
 
-        return Column(
-          children: [
-            if (haveSelection)
+        return DefaultTabController(
+          length: 2,
+          child: Column(children: [
+            const TabBar(tabs: [
+              Tab(text: 'Upcoming'),
+              Tab(text: 'Past'),
+            ]),
+            Expanded(
+              child: TabBarView(children: [
+                SeatingList(
+                  when: When.upcoming,
+                  state: state,
+                  showAll: showAll,
+                ),
+                SeatingList(
+                  when: When.past,
+                  state: state,
+                  showAll: showAll,
+                ),
+              ]),
+            ),
+            if (state.selected != null)
               SwitchListTile(
                 title: const Text('Selected Player / All Players'),
                 value: showAll,
                 onChanged: toggleShowAll,
               ),
-            Expanded(
-              child: ListView(
-                children: [
-                  for (final round in seats)
-                    HanchanTable(
-                      round: round,
-                      schedule: state.schedule,
-                      roundDone: state.roundDone,
-                    ),
-                ],
-              ),
-            ),
-          ],
+          ]),
         );
       },
+    );
+  }
+}
+
+enum When {
+  upcoming,
+  past,
+}
+
+class SeatingList extends StatelessWidget {
+  const SeatingList({
+    super.key,
+    required this.when,
+    required this.state,
+    required this.showAll,
+  });
+
+  final When when;
+  final SeatingState state;
+  final bool showAll;
+
+  Iterable<Round> get seats {
+    final now = DateTime.now();
+    return state.rounds.where((round) {
+      return switch (when) {
+        When.upcoming => round.start.isAfter(now),
+        When.past => !round.start.isAfter(now),
+      };
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final seats = switch (when) {
+      When.upcoming => this.seats,
+      When.past => this.seats.toList().reversed,
+    };
+    if (seats.isEmpty) {
+      return const Center(child: Text('No seating schedule available'));
+    }
+
+    return CustomScrollView(
+      slivers: [
+        for (final round in seats)
+          SliverStickyHeader(
+            header: Material(
+              color: Theme.of(context).cardColor,
+              elevation: 1,
+              child: ListTile(
+                leading: const Icon(Icons.watch_later_outlined),
+                title: Text(round.name),
+                subtitle:
+                    Text(DateFormat('EEEE d MMMM HH:mm').format(round.start)),
+                visualDensity: VisualDensity.compact,
+              ),
+            ),
+            sliver: SliverList(
+              delegate: SliverChildListDelegate([
+                for (final table in round.tables)
+                  if (showAll ||
+                      state.selected == null ||
+                      table.hasPlayerId(state.selected))
+                    Column(children: [
+                      ListTile(
+                        leading: const Icon(Icons.table_restaurant),
+                        title: Text(table.name),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        child: AssignedTable(
+                          players: table.players,
+                          selected: state.selected,
+                          japaneseWinds: state.japaneseWinds,
+                        ),
+                      ),
+                    ]),
+              ]),
+            ),
+          ),
+      ],
     );
   }
 }
 
 typedef AssignedTableState = ({
   int? selected,
-  Map playerMap,
+  List<Player> players,
   bool japaneseWinds,
 });
 
 class AssignedTable extends StatelessWidget {
-  const AssignedTable(
-    this.seats, {
+  const AssignedTable({
+    required this.players,
+    this.selected,
+    required this.japaneseWinds,
     super.key,
   });
 
-  final List<int> seats; // E,S,N,W player indices
+  final Map<Winds, Player> players;
+  final int? selected;
+  final bool japaneseWinds;
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AllState, AssignedTableState>(
-      converter: (store) => (
-        selected: store.state.selected,
-        playerMap: store.state.playerMap,
-        japaneseWinds: prefs.getBool('japaneseWinds') ?? false,
+    return Table(
+      border: TableBorder.all(
+        width: 2,
+        color: const Color(0x88888888),
       ),
-      builder: (context, state) {
-        return Table(
-          border: TableBorder.all(
-            width: 2,
-            color: const Color(0x88888888),
-          ),
-          columnWidths: const {
-            0: IntrinsicColumnWidth(),
-            1: FlexColumnWidth(),
-          },
-          children: [
-            for (final wind in Winds.values)
-              TableRow(
-                decoration: BoxDecoration(
-                  color: seats[wind.index] == state.selected
-                      ? selectedHighlight
-                      : Colors.transparent,
-                ),
-                children: [
-                  //selected: seats[wind.index] == s.selected,
-                  Padding(
-                    padding: const EdgeInsets.all(8),
-                    child: Text(
-                      switch (state.japaneseWinds) {
-                        true => wind.japanese,
-                        false => wind.western,
-                      },
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(8),
-                    child: Text(state.playerMap[seats[wind.index]]!),
-                  ),
-                ],
-              ),
-          ],
-        );
+      columnWidths: const {
+        0: IntrinsicColumnWidth(),
+        1: FlexColumnWidth(),
       },
-    );
-  }
-}
-
-class HanchanTable extends StatelessWidget {
-  const HanchanTable({
-    super.key,
-    required this.round,
-    required this.schedule,
-    required this.roundDone,
-  });
-
-  final RoundState round;
-  final ScheduleState schedule;
-  final int roundDone;
-
-  @override
-  Widget build(BuildContext context) {
-    final roundName = schedule.hanchan[round.id]!.name;
-    final startTime = DateFormat('EEEE d MMMM HH:mm')
-        .format(schedule.hanchan[round.id]!.start);
-
-    return Column(children: [
-      Container(
-        margin: const EdgeInsets.all(8.0),
-        decoration: const BoxDecoration(
-          border: Border(
-            top: BorderSide(
-              width: 3,
-              color: Colors.blueAccent,
+      children: [
+        for (final wind in Winds.values)
+          TableRow(
+            decoration: BoxDecoration(
+              color: players[wind]?.id == selected
+                  ? selectedHighlight
+                  : Colors.transparent,
             ),
-          ),
-        ),
-      ),
-      ListTile(
-        leading: const Icon(Icons.watch_later_outlined),
-        title: Text("$roundName begins at $startTime"),
-      ),
-      for (final MapEntry(:key, :value) in round.tables.entries)
-        Column(children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              const Icon(Icons.table_restaurant),
-              Text(' $key'),
+              Padding(
+                padding: const EdgeInsets.all(8),
+                child: Text(
+                  switch (japaneseWinds) {
+                    true => wind.japanese,
+                    false => wind.western,
+                  },
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(8),
+                child: Text(players[wind]!.name),
+              ),
             ],
           ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: AssignedTable(value),
-          ),
-          const SizedBox(height: 10),
-        ])
-    ]);
+      ],
+    );
   }
 }

--- a/lib/tournament.dart
+++ b/lib/tournament.dart
@@ -8,26 +8,30 @@ import 'seats.dart';
 import 'store.dart';
 import 'utils.dart';
 
-typedef TournamentPageState = ({
-  TournamentState tournament,
-  int pageIndex,
-});
-
-class TournamentPage extends StatelessWidget {
+class TournamentPage extends StatefulWidget {
   const TournamentPage({super.key});
 
   @override
+  State<TournamentPage> createState() => _TournamentPageState();
+}
+
+class _TournamentPageState extends State<TournamentPage> {
+  int pageIndex = 0;
+
+  @override
   Widget build(BuildContext context) {
-    return StoreConnector<AllState, TournamentPageState>(
-      converter: (store) => (
-        tournament: store.state.tournament!,
-        pageIndex: store.state.pageIndex,
-      ),
-      builder: (context, state) {
+    return StoreConnector<AllState, TournamentState?>(
+      distinct: true,
+      converter: (store) => store.state.tournament,
+      builder: (context, tournament) {
+        if (tournament == null) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
         return Scaffold(
           appBar: AppBar(
             backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-            title: Text(state.tournament.name),
+            title: Text(tournament.name),
             actions: [
               IconButton(
                 icon: const Icon(Icons.settings),
@@ -36,7 +40,7 @@ class TournamentPage extends StatelessWidget {
             ],
           ),
           body: IndexedStack(
-            index: state.pageIndex,
+            index: pageIndex,
             children: const [
               Seating(),
               Players(),
@@ -46,10 +50,8 @@ class TournamentPage extends StatelessWidget {
           ),
           bottomNavigationBar: BottomNavigationBar(
             type: BottomNavigationBarType.fixed,
-            currentIndex: state.pageIndex,
-            onTap: (index) => store.dispatch(
-              SetPageIndexAction(pageIndex: index),
-            ),
+            currentIndex: pageIndex,
+            onTap: (index) => setState(() => pageIndex = index),
             items: const [
               BottomNavigationBarItem(
                 icon: Icon(Icons.airline_seat_recline_normal_outlined),

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -6,6 +6,8 @@
  This is to avoid circular dependencies.
 
  */
+import 'dart:async';
+
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -179,6 +181,27 @@ extension SeperatedBy<T> on Iterable<T> {
     while (iterator.moveNext()) {
       yield seperator;
       yield iterator.current;
+    }
+  }
+}
+
+class RunOrQueue {
+  FutureOr<void> Function()? current;
+  FutureOr<void> Function()? next;
+
+  Future<void> call(FutureOr<void> Function() block) async {
+    if (current != null) {
+      next = block;
+      return;
+    }
+    current = block;
+    while (current != null) {
+      try {
+        await current!();
+      } finally {
+        current = next;
+        next = null;
+      }
     }
   }
 }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -8,6 +8,7 @@
  */
 import 'dart:async';
 
+import 'package:equatable/equatable.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -45,9 +46,6 @@ const Map<String, Color> BACKGROUND_COLOURS = {
   'fireball red': Color(0xFF330000),
   'deep purple': Color(0xFF220033),
 };
-
-final GlobalKey<NavigatorState> globalNavigatorKey =
-    GlobalKey<NavigatorState>();
 
 String dateRange(dynamic startDT, dynamic endDT) {
   if (startDT == null || endDT == null) return '';
@@ -89,22 +87,50 @@ enum Winds {
   final String western;
 }
 
-class Player implements Comparable<Player> {
-  int id = -99;
-  String name = '';
+class Player extends Equatable implements Comparable<Player> {
+  const Player(this.id, this.name);
 
-  Player(this.id, this.name);
+  final int id;
+  final String name;
 
   @override
   int compareTo(Player other) => name.compareTo(other.name);
 
   @override
   toString() => '$name ($id)';
+
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+      ];
+}
+
+extension PlayerList on List<Player> {
+  Player? byId(int id) {
+    try {
+      return firstWhere((player) => player.id == id);
+    } on StateError {
+      return null;
+    }
+  }
 }
 
 typedef SeatingPlan = List<RoundState>;
 
-class RoundState {
+extension RoundList on List<RoundState> {
+  Iterable<RoundState> withPlayerId(int? playerId) => playerId == null
+      ? this
+      : map((round) => RoundState(
+            id: round.id,
+            tables: {
+              for (final MapEntry(:key, :value) in round.tables.entries)
+                if (value.contains(playerId)) key: value,
+            },
+          ));
+}
+
+class RoundState extends Equatable {
   const RoundState({
     required this.id,
     required this.tables,
@@ -122,6 +148,15 @@ class RoundState {
 
   final String id;
   final Map<String, List<int>> tables;
+
+  String tableNameForPlayerId(int playerId) =>
+      tables.entries.firstWhere((e) => e.value.contains(playerId)).key;
+
+  @override
+  List<Object?> get props => [
+        id,
+        tables,
+      ];
 }
 
 /// Get the seating for an individual player

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -106,7 +106,7 @@ packages:
     source: hosted
     version: "3.12.3"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.5.12"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   fake_async:
     dependency: transitive
     description:
@@ -294,6 +302,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.10.0"
+  flutter_sticky_header:
+    dependency: "direct main"
+    description:
+      name: flutter_sticky_header
+      sha256: "017f398fbb45a589e01491861ca20eb6570a763fd9f3888165a978e11248c709"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.5"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -741,6 +757,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  value_layout_builder:
+    dependency: transitive
+    description:
+      name: value_layout_builder
+      sha256: "98202ec1807e94ac72725b7f0d15027afde513c55c69ff3f41bcfccb950831bc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: "direct main"
     description:
       name: alarm
-      sha256: "7af646392a9c52baeb9f7981d4a56c2e5c72b44ec1a7f72cea06d18212808260"
+      sha256: "944d2a8ffbd5317a71f1d63785a395b97baef97aa918a1c8141897e2a643a51a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.4"
   archive:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none'
 # In iOS, build name is used as CFBundleShortVersionString
 # build number is used as CFBundleVersion.
 
-version: 0.3.2+26
+version: 0.3.2+27
 
 environment:
   sdk: '>=3.2.5 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none'
 # In iOS, build name is used as CFBundleShortVersionString
 # build number is used as CFBundleVersion.
 
-version: 0.3.2+27
+version: 0.3.2+28
 
 environment:
   sdk: '>=3.2.5 <4.0.0'
@@ -26,11 +26,14 @@ dependencies:
 
   alarm: ^3.1.3
   cloud_firestore: ^4.15.9
+  collection: ^1.18.0
   data_table_2: ^2.5.12
+  equatable: ^2.0.5
   firebase_core: any
   firebase_messaging: ^14.0.0
   flutter_autostart: ^0.0.2
   flutter_redux: ^0.10.0
+  flutter_sticky_header: ^0.6.5
   flutter_timezone: ^1.0.8
   flutter_typeahead: ^5.2.0
   intl: ^0.19.0


### PR DESCRIPTION
Sorry, should have split this up into smaller commits. This PR includes:
* Added text for when Tournaments list was empty. I believe this was the "blank" screen apple were complaining about
* This adds a delay to setting alarms (100ms) and makes sure `setAlarms` can only called once. This prevents the crashing when selecting a player
* Splits Seating into Upcoming and Past tabs. Upcoming has the next round at the top and Past has last round at the top.
* Seating has sticky headers for rounds
* Made views only update when data had changed
* AllState is now immutable
* Scrolling the player list is now hidden behind the search box
* The player you're following is now always shown at the top in the Scores tab
* Various small UI tweaks


<img src="https://github.com/ApplySci/aim/assets/1031451/8edc3c9b-57a9-4004-a6b9-a731746141eb" width="50%"/>
<img src="https://github.com/ApplySci/aim/assets/1031451/bed3ec5a-3873-48d4-9c3c-aa5ce4e46d65" width="50%"/>
